### PR TITLE
CLOSES #29: Removes unsupported environment variables.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,14 +53,8 @@ EXPOSE 80 8443
 # -----------------------------------------------------------------------------
 ENV SSH_AUTOSTART_SSHD=false \
 	SSH_AUTOSTART_SSHD_BOOTSTRAP=false \
-	VARNISH_ADMIN_LISTEN_ADDRESS="127.0.0.1" \
-	VARNISH_ADMIN_LISTEN_PORT="6082" \
-	VARNISH_LISTEN_ADDRESS="0.0.0.0" \
-	VARNISH_LISTEN_PORT="80 -a 0.0.0.0:8443" \
 	VARNISH_MAX_THREADS="1000" \
 	VARNISH_MIN_THREADS="50" \
-	VARNISH_PIDFILE="/var/run/varnish.pid" \
-	VARNISH_SECRET_FILE="/etc/varnish/secret" \
 	VARNISH_STORAGE="file,/var/lib/varnish/varnish_storage.bin,1G" \
 	VARNISH_THREAD_TIMEOUT="120" \
 	VARNISH_TTL="120" \


### PR DESCRIPTION
Resolves #29 

- Removes unused variables from Dockerfile:
  - `VARNISH_ADMIN_LISTEN_ADDRESS`
  - `VARNISH_ADMIN_LISTEN_PORT`
  - `VARNISH_LISTEN_ADDRESS`
  - `VARNISH_LISTEN_PORT`
  - `VARNISH_PIDFILE`
  - `VARNISH_SECRET_FILE`