### PR TITLE
CLOSES #32: Adds PROXY protocol to the 8443 port binding.

### DIFF
--- a/etc/services-config/varnish/docker-default.vcl
+++ b/etc/services-config/varnish/docker-default.vcl
@@ -57,7 +57,8 @@ sub vcl_recv {
 		set req.http.X-Forwarded-For = client.ip;
 	}
 
-	if (std.port(server.ip) == 8443) {
+	if (std.port(server.ip) == 443 ||
+		std.port(server.ip) == 8443) {
 		# SSL Terminated upstream so indcate this with a custom header
 		set req.http.X-Forwarded-Port = "443";
 		set req.http.X-Forwarded-Proto = "https";

--- a/etc/services-config/varnish/docker-default.vcl
+++ b/etc/services-config/varnish/docker-default.vcl
@@ -71,7 +71,7 @@ sub vcl_recv {
 		return (synth(403));
 	}
 
-	set req.http.X-Varnish-Grace = "none";
+	# set req.http.X-Varnish-Grace = "none";
 
 	if (req.method != "GET" &&
 		req.method != "HEAD" &&

--- a/etc/services-config/varnish/docker-default.vcl
+++ b/etc/services-config/varnish/docker-default.vcl
@@ -50,13 +50,6 @@ sub vcl_recv {
 	unset req.http.X-Forwarded-Port;
 	unset req.http.X-Forwarded-Proto;
 
-	if (req.http.X-Forwarded-For &&
-		req.http.X-Forwarded-For != ("" + client.ip)) {
-		set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + client.ip;
-	} else if ( ! req.http.X-Forwarded-For) {
-		set req.http.X-Forwarded-For = client.ip;
-	}
-
 	if (std.port(server.ip) == 443 ||
 		std.port(server.ip) == 8443) {
 		# SSL Terminated upstream so indcate this with a custom header

--- a/usr/sbin/varnishd-wrapper
+++ b/usr/sbin/varnishd-wrapper
@@ -40,7 +40,7 @@ DAEMON_OPTS="-j unix,user=varnish,ccgroup=varnish
  -F
  -P /var/run/varnish.pid
  -a 0.0.0.0:80
- -a 0.0.0.0:8443
+ -a 0.0.0.0:8443,PROXY
  -f ${VARNISH_VCL_CONF:-/etc/varnish/docker-default.vcl}
  -T 127.0.0.1:6082
  -t ${VARNISH_TTL:-120}


### PR DESCRIPTION
Resolves #32 

- Adds PROXY protocol to the 8443 port binding.
- Removes grace header which is used for debugging.
- Removes duplicated X-Forwarded-For handling - unnecessary since Varnish 4 moved logic out of the default VCL configuration and leaving it in place results in duplicate entries in X-Forwarded-For.
