### PR TITLE
CLOSES #49: Fixes issue with expect script failure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-6 6.8 x86_64 - Varnish Cache 4.1.
 ### 1.4.0 - Unreleased
 
 - Adds SHPEC_ROOT variable to Makefile.
+- Fixes issue with expect script failure when using `expect -f`.
 
 ### 1.3.2 - 2017-04-26
 

--- a/test/telnet-proxy-tcp4.exp
+++ b/test/telnet-proxy-tcp4.exp
@@ -1,4 +1,4 @@
-#!/usr/bin/env expect -f
+#!/usr/bin/env expect
 
 set env(HOME) /usr/local/bin
 set env(SHELL) /bin/bash


### PR DESCRIPTION
Resolves #49 

- Fixes issue with expect script failure when using `expect -f`.