### PR TITLE
CLOSES #65: Updates varnish to version 4.1.8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.9 x86_64 - Varnish Cache 4.1.
 
+### 1.4.1 - Unreleased
+
+- Updates varnish to version 4.1.8.
+
 ### 1.4.0 - 2017-08-03
 
 - Adds `SHPEC_ROOT` variable to Makefile.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,12 @@ FROM jdeathe/centos-ssh:1.8.1
 # Install Varnish Cache
 # -----------------------------------------------------------------------------
 RUN rpm --rebuilddb \
-	&& rpm --import https://repo.varnish-cache.org/GPG-key.txt \
-	&& rpm -i https://repo.varnish-cache.org/redhat/varnish-4.1.el6.rpm \
+	&& rpm -iv https://packagecloud.io/varnishcache/varnish41/packages/el/6/varnish-release-4.1-4.el6.noarch.rpm/download \
 	&& yum -y install \
 		--setopt=tsflags=nodocs \
 		--disableplugin=fastestmirror \
 		gcc-4.4.7-18.el6 \
-		varnish-4.1.7-1.el6 \
+		varnish-4.1.8-1.el6 \
 	&& yum versionlock add \
 		varnish \
 		gcc \


### PR DESCRIPTION
Resolves #65, #67 

- Updates varnish to version 4.1.8 (using new packagecloud.io repository).