### PR TITLE
CLOSES #63: Adds use of readonly variables for SCMI constants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.9 x86_64 - Varnish Cache 4.1.
 
+### 1.4.1 - Unreleased
+
+- Adds use of readonly variables for scmi constants.
+
 ### 1.4.0 - 2017-08-03
 
 - Adds `SHPEC_ROOT` variable to Makefile.

--- a/src/opt/scmi/service-unit.sh
+++ b/src/opt/scmi/service-unit.sh
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # Constants
 # -----------------------------------------------------------------------------
-SERVICE_UNIT_ENVIRONMENT_KEYS="
+readonly SERVICE_UNIT_ENVIRONMENT_KEYS="
  DOCKER_CONTAINER_OPTS
  DOCKER_IMAGE_PACKAGE_PATH
  DOCKER_IMAGE_TAG
@@ -18,7 +18,7 @@ SERVICE_UNIT_ENVIRONMENT_KEYS="
  VARNISH_VCL_CONF
 "
 
-SERVICE_UNIT_REGISTER_ENVIRONMENT_KEYS="
+readonly SERVICE_UNIT_REGISTER_ENVIRONMENT_KEYS="
  REGISTER_ETCD_PARAMETERS
  REGISTER_TTL
  REGISTER_UPDATE_INTERVAL


### PR DESCRIPTION
Resolves #63 

- Adds use of readonly variables for scmi constants.