### PR TITLE
CLOSES #113: Updates source image to 1.9.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-6 6.9 x86_64 - Varnish Cache 4.1.
 ### 1.5.0 - Unreleased
 
 - Updates `gcc` package to 4.4.7-23.
+- Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).
 
 ### 1.4.4 - 2018-06-22
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # CentOS-6, Varnish 4.1
 #
 # =============================================================================
-FROM jdeathe/centos-ssh:1.8.4
+FROM jdeathe/centos-ssh:1.9.0
 
 # -----------------------------------------------------------------------------
 # Install Varnish Cache
@@ -93,7 +93,7 @@ jdeathe/centos-ssh-varnish:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-varnish" \
-	org.deathe.description="CentOS-6 6.9 x86_64 - Varnish Cache 4.1."
+	org.deathe.description="CentOS-6 6.10 x86_64 - Varnish Cache 4.1."
 
 HEALTHCHECK \
 	--interval=0.5s \

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-CentOS-6 6.9 x86_64 - Varnish Cache.
+CentOS-6 6.10 x86_64 - Varnish Cache.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ centos-ssh-varnish
 ==================
 
 Docker Image including:
-- CentOS-6 6.9 x86_64 and Varnish Cache 4.1.
-- CentOS-7 7.4.1708 x86_64 and Varnish Cache 6.0.
+- CentOS-6 6.10 x86_64 and Varnish Cache 4.1.
+- CentOS-7 7.5.1804 x86_64 and Varnish Cache 6.0.
 
 ## Overview & links
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       APACHE_SERVER_NAME: "www.app.local"
       PHP_OPTIONS_SESSION_SAVE_HANDLER: "memcached"
       PHP_OPTIONS_SESSION_SAVE_PATH: "memcached:11211"
-    image: "jdeathe/centos-ssh-apache-php:2.2.6"
+    image: "jdeathe/centos-ssh-apache-php:2.3.0"
     networks:
       tier2:
         aliases:
@@ -75,7 +75,7 @@ services:
     environment:
       MEMCACHED_CACHESIZE: "32"
       MEMCACHED_MAXCONN: "2048"
-    image: "jdeathe/centos-ssh-memcached:1.1.3"
+    image: "jdeathe/centos-ssh-memcached:1.2.0"
     networks:
       - "tier2"
     restart: "always"


### PR DESCRIPTION
CLOSES #113

- Updates source image to [1.9.0](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.0).