### PR TITLE
CLOSES #107: Updates Varnish to 6.0.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.0.
 ### 2.1.0 - Unreleased
 
 - Updates source image to [2.4.0](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.0).
+- Updates Varnish to [6.0.1](https://github.com/varnishcache/varnish-cache/blob/varnish-6.0.1/doc/changes.rst)
 
 ### 2.0.0 - 2018-06-22
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN { \
 		--setopt=tsflags=nodocs \
 		--disableplugin=fastestmirror \
 		gcc-4.8.5-28.el7_5.1 \
-		varnish-6.0.0-1.el7 \
+		varnish-6.0.1-1.el7 \
 	&& yum versionlock add \
 		varnish \
 		gcc \


### PR DESCRIPTION
CLOSES #107

- Updates Varnish to [6.0.1](https://github.com/varnishcache/varnish-cache/blob/varnish-6.0.1/doc/changes.rst)