### PR TITLE
CLOSES #142: Fixes format/filter typo in tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 2.
 
 CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.1.
 
+### 2.2.1 - Unreleased
+
+- Fixes typo in test; using `--format` instead of `--filter`.
+
 ### 2.2.0 - 2018-10-09
 
 - Updates Varnish to [6.1.0](https://github.com/varnishcache/varnish-cache/blob/varnish-6.1.0/doc/changes.rst)

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -796,8 +796,8 @@ function test_custom_configuration ()
 			sleep ${STARTUP_TIME}
 
 			docker ps \
-				--format "name=varnish.pool-1.1.1" \
-				--format "health=healthy" \
+				--filter "name=varnish.pool-1.1.1" \
+				--filter "health=healthy" \
 			&> /dev/null \
 			&& docker top \
 				varnish.pool-1.1.1 \
@@ -833,8 +833,8 @@ function test_custom_configuration ()
 			fi
 
 			docker ps \
-				--format "name=varnish.pool-1.1.1" \
-				--format "health=healthy" \
+				--filter "name=varnish.pool-1.1.1" \
+				--filter "health=healthy" \
 			&> /dev/null \
 			&& docker top \
 				varnish.pool-1.1.1 \


### PR DESCRIPTION
CLOSES #142

- Fixes typo in test; using `--format` instead of `--filter`.