### PR TITLE
CLOSES #143: Fixes format/filter typo in tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Summary of release changes for Version 1.
 
 CentOS-6 6.10 x86_64 - Varnish Cache 4.1.
 
+### 1.5.2 - Unreleased
+
+- Fixes typo in test; using `--format` instead of `--filter`.
+
 ### 1.5.1 - 2018-10-09
 
 - Adds lockfile to ensure varnishd is started before varnishncsa.

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -796,8 +796,8 @@ function test_custom_configuration ()
 			sleep ${STARTUP_TIME}
 
 			docker ps \
-				--format "name=varnish.pool-1.1.1" \
-				--format "health=healthy" \
+				--filter "name=varnish.pool-1.1.1" \
+				--filter "health=healthy" \
 			&> /dev/null \
 			&& docker top \
 				varnish.pool-1.1.1 \
@@ -833,8 +833,8 @@ function test_custom_configuration ()
 			fi
 
 			docker ps \
-				--format "name=varnish.pool-1.1.1" \
-				--format "health=healthy" \
+				--filter "name=varnish.pool-1.1.1" \
+				--filter "health=healthy" \
 			&> /dev/null \
 			&& docker top \
 				varnish.pool-1.1.1 \


### PR DESCRIPTION
CLOSES #143

- Fixes typo in test; using `--format` instead of `--filter`.