### PR TITLE
CLOSES #148: Updates Varnish to 6.1.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.1.
 
 - Fixes typo in test; using `--format` instead of `--filter`.
 - Updates source image to [2.4.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.1).
+- Updates Varnish to [6.1.1](https://github.com/varnishcache/varnish-cache/blob/varnish-6.1.1/doc/changes.rst)
 - Adds required `--sysctl` settings to docker run templates.
 
 ### 2.2.0 - 2018-10-09

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN { \
 		--setopt=tsflags=nodocs \
 		--disableplugin=fastestmirror \
 		gcc-4.8.5-28.el7_5.1 \
-		varnish-6.1.0-1.el7 \
+		varnish-6.1.1-1.el7 \
 	&& yum versionlock add \
 		varnish \
 		gcc \


### PR DESCRIPTION
CLOSES #148

- Updates Varnish to [6.1.1](https://github.com/varnishcache/varnish-cache/blob/varnish-6.1.1/doc/changes.rst)