### PR TITLE
CLOSES #159: Patches back #155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ CentOS-6 6.10 x86_64 - Varnish Cache 4.1.
 - Fixes typo in test; using `--format` instead of `--filter`.
 - Updates source image to [1.9.1](https://github.com/jdeathe/centos-ssh/releases/tag/1.9.1).
 - Adds required `--sysctl` settings to docker run templates.
+- Adds change to ensure varnishncsa is run with a non-root user `varnishlog`.
+- Adds varnishncsa access logs to docker log output.
+- Adds "Varnish Details" to docker log output.
 
 ### 1.5.1 - 2018-10-09
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,17 +50,26 @@ RUN ln -sf \
 	&& chmod 644 \
 		/etc/varnish/*.vcl \
 	&& chmod 700 \
-		/usr/{bin/healthcheck,sbin/{varnishd,varnishncsa}-wrapper}
+		/usr/{bin/healthcheck,sbin/{varnishd,varnishncsa}-wrapper} \
+	&& chmod 750 \
+		/usr/sbin/varnishncsa-wrapper \
+	&& chgrp varnish \
+		/usr/sbin/varnishncsa-wrapper \
+	&& mkdir -p \
+		/var/run/varnish \
+	&& chown \
+		varnishlog:varnish \
+		/var/run/varnish
 
 EXPOSE 80 8443
 
 # -----------------------------------------------------------------------------
 # Set default environment variables
 # -----------------------------------------------------------------------------
-ENV SSH_AUTOSTART_SSHD=false \
-	SSH_AUTOSTART_SSHD_BOOTSTRAP=false \
-	VARNISH_AUTOSTART_VARNISHD_WRAPPER=true \
-	VARNISH_AUTOSTART_VARNISHNCSA_WRAPPER=false \
+ENV SSH_AUTOSTART_SSHD="false" \
+	SSH_AUTOSTART_SSHD_BOOTSTRAP="false" \
+	VARNISH_AUTOSTART_VARNISHD_WRAPPER="true" \
+	VARNISH_AUTOSTART_VARNISHNCSA_WRAPPER="false" \
 	VARNISH_MAX_THREADS="1000" \
 	VARNISH_MIN_THREADS="50" \
 	VARNISH_STORAGE="file,/var/lib/varnish/varnish_storage.bin,1G" \

--- a/src/etc/services-config/supervisor/supervisord.d/varnishncsa-wrapper.conf
+++ b/src/etc/services-config/supervisor/supervisord.d/varnishncsa-wrapper.conf
@@ -2,8 +2,9 @@
 priority = 150
 command = /usr/sbin/varnishncsa-wrapper
 autostart = %(ENV_VARNISH_AUTOSTART_VARNISHNCSA_WRAPPER)s
-startsecs = 0
+startsecs = 1
 autorestart = true
 redirect_stderr = true
-stdout_logfile = /var/log/varnish.log
+stdout_logfile = /var/log/varnish/access_log
 stdout_events_enabled = true
+user = varnishlog

--- a/src/usr/sbin/varnishd-wrapper
+++ b/src/usr/sbin/varnishd-wrapper
@@ -1,7 +1,76 @@
 #!/usr/bin/env bash
 
+set -e
+
+readonly BIN="/usr/sbin/varnishd"
+readonly GROUP="varnish"
+readonly LOCK_FILE="/var/lock/subsys/varnishd-wrapper"
+readonly NICE="/bin/nice"
+readonly NICENESS="10"
+readonly TIMER_START="$(
+	date +%s.%N
+)"
+readonly USER="varnish"
+readonly SECRET_PATH="/etc/varnish/secret"
+readonly VARNISHNCSA_GROUP="varnish"
+readonly VARNISHNCSA_LOG_FILE="/var/log/varnish/access_log"
+readonly VARNISHNCSA_USER="varnishlog"
+readonly VARNISHNCSA_WRAPPER="/usr/sbin/varnishncsa-wrapper"
+
+OPTIONS=""
+VARNISHNCSA_FORMAT=""
+
 # Create lock file
-touch /var/lock/subsys/varnishd-wrapper
+touch \
+	"${LOCK_FILE}"
+
+function populate_psk_secret_file ()
+{
+	local file_path="${1:-/etc/varnish/secret}"
+	local user="${2:-varnish}"
+	local group="${3:-varnish}"
+
+	if [[ ! -s ${file_path} ]]
+	then
+		printf -- \
+			"Populating Varnish PSK secret file.\n"
+
+		dd \
+			if=/dev/urandom \
+			of="${file_path}" \
+			count=1 \
+		&> /dev/null
+
+		chown \
+			${user}:${group} \
+			"${file_path}"
+
+		chmod \
+			640 \
+			"${file_path}"
+	fi
+}
+
+function set_log_write_user ()
+{
+	local file_path="${1:-}"
+	local user="${2:-}"
+	local group="${3:-}"
+
+	if [[ ! -f ${file_path} ]]
+	then
+		touch \
+			"${file_path}"
+	fi
+
+	chown \
+		"${user}":"${group}" \
+		"${file_path}"
+
+	chmod \
+		0660 \
+		"${file_path}"
+}
 
 function set_varnish_vcl_conf ()
 {
@@ -35,9 +104,39 @@ function set_varnish_vcl_conf ()
 	fi
 }
 
-set_varnish_vcl_conf "${VARNISH_VCL_CONF}"
+function set_wrapper_execute_group ()
+{
+	local file_path="${1:-}"
+	local group="${2:-}"
 
-readonly DAEMON_OPTS="-j unix,user=varnish,ccgroup=varnish
+	chgrp \
+		"${group}" \
+		"${file_path}"
+
+	chmod \
+		0750 \
+		"${file_path}"
+}
+
+# Ensure the secret PSK file is present.
+populate_psk_secret_file \
+	"${SECRET_PATH}" \
+	"${USER}" \
+	"${GROUP}"
+
+set_wrapper_execute_group \
+	"${VARNISHNCSA_WRAPPER}" \
+	"${VARNISHNCSA_GROUP}"
+
+set_log_write_user \
+	"${VARNISHNCSA_LOG_FILE}" \
+	"${VARNISHNCSA_USER}" \
+	"${VARNISHNCSA_GROUP}"
+
+set_varnish_vcl_conf \
+	"${VARNISH_VCL_CONF}"
+
+OPTIONS="-j unix,user=${USER},ccgroup=${GROUP}
  -F
  -P /var/run/varnish.pid
  -a 0.0.0.0:80
@@ -48,21 +147,45 @@ readonly DAEMON_OPTS="-j unix,user=varnish,ccgroup=varnish
  -p thread_pool_min=${VARNISH_MIN_THREADS:-50}
  -p thread_pool_max=${VARNISH_MAX_THREADS:-1000}
  -p thread_pool_timeout=${VARNISH_THREAD_TIMEOUT:-120}
- -S /etc/varnish/secret
+ -S ${SECRET_PATH}
  -s ${VARNISH_STORAGE:-file,/var/lib/varnish/varnish_storage.bin,1G}
 "
-readonly NICE="/bin/nice"
-readonly NICENESS="${VARNISH_NICENESS:-10}"
-readonly VARNISHD="/usr/sbin/varnishd"
 
-printf -- \
-	"Starting Varnish Cache: \n %s\n" \
-	"${DAEMON_OPTS}"
+if [[ ${VARNISH_AUTOSTART_VARNISHNCSA_WRAPPER} == true ]]
+then
+	VARNISHNCSA_FORMAT="${VARNISH_VARNISHNCSA_FORMAT:-"%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\""}"
+fi
+
+TIMER_TOTAL="$(
+	echo - | awk "\
+	{ T1=\"${TIMER_START}\" } \
+	{ T2=\"$(date +%s.%N)\" } \
+	{ print T2 - T1; }"
+)"
+
+cat \
+	<<-EOT
+
+	================================================================================
+	Varnish Details
+	--------------------------------------------------------------------------------
+	vcl : ${VARNISH_VCL_CONF:-/etc/varnish/docker-default.vcl}
+	storage : ${VARNISH_STORAGE:-file,/var/lib/varnish/varnish_storage.bin,1G}
+	ttl : ${VARNISH_TTL:-120}
+	thread_pool_min : ${VARNISH_MIN_THREADS:-50}
+	thread_pool_max : ${VARNISH_MAX_THREADS:-1000}
+	thread_pool_timeout: ${VARNISH_THREAD_TIMEOUT:-120}
+	varnishncsa format : ${VARNISHNCSA_FORMAT:-N/A}
+	--------------------------------------------------------------------------------
+	${TIMER_TOTAL}
+
+EOT
 
 # Release lock file
-rm -f /var/lock/subsys/varnishd-wrapper
+rm -f \
+	"${LOCK_FILE}"
 
 exec ${NICE} \
 	-n ${NICENESS} \
-	${VARNISHD} \
-	${DAEMON_OPTS}
+	${BIN} \
+	${OPTIONS}

--- a/src/usr/sbin/varnishncsa-wrapper
+++ b/src/usr/sbin/varnishncsa-wrapper
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
 
-readonly DAEMON_OPTS="-a
- -c
- -P /var/run/varnishncsa.pid
- -w /var/log/varnish/access_log
-"
+readonly BIN="/usr/bin/varnishncsa"
 readonly FORMAT="${VARNISH_VARNISHNCSA_FORMAT:-"%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\""}"
-readonly NICE=/bin/nice
-readonly NICENESS=${VARNISHNCSA_NICENESS:-10}
-readonly VARNISHNCSA=/usr/bin/varnishncsa
+readonly LOCK_FILE="/var/lock/subsys/varnishd-wrapper"
+readonly NICE="/bin/nice"
+readonly NICENESS="10"
+readonly OPTIONS="-a
+ -c
+ -P /var/run/varnish/varnishncsa.pid
+"
 
-printf -- \
-	"Starting Varnish Apache/NCSA logging: \n %s -F %s\n\n" \
-	"${DAEMON_OPTS}" \
-	"${FORMAT}"
+while true
+do
+	sleep 0.1
+	[[ -e ${LOCK_FILE} ]] || break
+done
 
 exec ${NICE} \
 	-n ${NICENESS} \
-	${VARNISHNCSA} \
-	${DAEMON_OPTS} \
+	${BIN} \
+	${OPTIONS} \
 	-F "${FORMAT}"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -281,14 +281,14 @@ function test_basic_operations ()
 			it "Sets a 1G file storage."
 				assert __shpec_matcher_egrep \
 					"${varnish_logs}" \
-					"[ ]+-s file,\/var\/lib\/varnish\/varnish_storage\.bin,1G"
+					"^storage : file,\/var\/lib\/varnish\/varnish_storage\.bin,1G"
 			end
 
 			describe "VCL file"
 				it "Sets path to docker-default.vcl."
 					assert __shpec_matcher_egrep \
 						"${varnish_logs}" \
-						"[ ]+-f \/etc\/varnish\/docker-default\.vcl"
+						"^vcl : \/etc\/varnish\/docker-default\.vcl"
 				end
 
 				it "Is unaltered."
@@ -732,14 +732,14 @@ function test_custom_configuration ()
 			it "Sets a 256M malloc storage."
 				assert __shpec_matcher_egrep \
 					"${varnish_logs}" \
-					"[ ]+-s malloc,256M"
+					"^storage : malloc,256M"
 			end
 
 			describe "VCL file"
 				it "Sets path to docker-default.vcl."
 					assert __shpec_matcher_egrep \
 						"${varnish_logs}" \
-						"[ ]+-f \/etc\/varnish\/docker-default\.vcl"
+						"^vcl : \/etc\/varnish\/docker-default\.vcl"
 				end
 
 				it "Is unaltered."
@@ -891,9 +891,7 @@ function test_custom_configuration ()
 
 			# Ensure log file exists before checking it's contents
 			counter=0
-			until docker exec \
-				varnish.pool-1.1.1 \
-				bash -c "[[ -s /var/log/varnish/access_log ]]"
+			while true
 			do
 				if (( counter > 6 ))
 				then
@@ -906,6 +904,13 @@ function test_custom_configuration ()
 					-H "Host: ${backend_hostname}" \
 					http://127.0.0.1:${container_port_80}/ \
 				&> /dev/null
+
+				if docker exec \
+					varnish.pool-1.1.1 \
+					bash -c "[[ -s /var/log/varnish/access_log ]]"
+				then
+					break
+				fi
 
 				sleep 0.5
 				(( counter += 1 ))
@@ -965,9 +970,7 @@ function test_custom_configuration ()
 
 			# Ensure log file exists before checking it's contents
 			counter=0
-			until docker exec \
-				varnish.pool-1.1.1 \
-				bash -c "[[ -s /var/log/varnish/access_log ]]"
+			while true
 			do
 				if (( counter > 6 ))
 				then
@@ -980,6 +983,13 @@ function test_custom_configuration ()
 					-H "Host: ${backend_hostname}" \
 					http://127.0.0.1:${container_port_80}/ \
 				&> /dev/null
+
+				if docker exec \
+					varnish.pool-1.1.1 \
+					bash -c "[[ -s /var/log/varnish/access_log ]]"
+				then
+					break
+				fi
 
 				sleep 0.5
 				(( counter += 1 ))


### PR DESCRIPTION
CLOSES #159

- Adds change to ensure varnishncsa is run with a non-root user `varnishlog`.
- Adds varnishncsa access logs to docker log output.
- Adds "Varnish Details" to docker log output.