### PR TITLE
CLOSES #164: Updates gcc package to fix build failures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.1.
 
 - Fixes typo in test; using `--format` instead of `--filter`.
 - Updates source image to [2.4.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.1).
-- Updates Varnish to [6.1.1](https://github.com/varnishcache/varnish-cache/blob/varnish-6.1.1/doc/changes.rst)
+- Updates Varnish to [6.1.1](https://github.com/varnishcache/varnish-cache/blob/varnish-6.1.1/doc/changes.rst).
+- Updates `gcc` packages to 4.8.5-36.
 - Adds required `--sysctl` settings to docker run templates.
 - Adds change to ensure varnishncsa is run with a non-root user `varnishlog`.
 - Adds varnishncsa access logs to docker log output.

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN { \
 	&& yum -y install \
 		--setopt=tsflags=nodocs \
 		--disableplugin=fastestmirror \
-		gcc-4.8.5-28.el7_5.1 \
+		gcc-4.8.5-36.el7 \
 		varnish-6.1.1-1.el7 \
 	&& yum versionlock add \
 		varnish \


### PR DESCRIPTION
CLOSES #164

- Updates `gcc` packages to 4.8.5-36.