### PR TITLE
CLOSES #172: Updates Varnish to 6.2.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.2.
 
 - Updates `gcc` package to gcc-4.8.5-36.el7_6.1.
 - Updates source image to [2.5.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.1).
-- Updates Varnish to [6.2.0](https://github.com/varnishcache/varnish-cache/blob/varnish-6.2.0/doc/changes.rst)
+- Updates Varnish to [6.2.0](https://github.com/varnishcache/varnish-cache/blob/varnish-6.2.0/doc/changes.rst).
 - Updates and restructures Dockerfile.
 - Updates container naming conventions and readability of `Makefile`.
 - Updates startup time to 3 seconds.
@@ -52,14 +52,14 @@ CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.2.
 
 ### 2.2.0 - 2018-10-09
 
-- Updates Varnish to [6.1.0](https://github.com/varnishcache/varnish-cache/blob/varnish-6.1.0/doc/changes.rst)
+- Updates Varnish to [6.1.0](https://github.com/varnishcache/varnish-cache/blob/varnish-6.1.0/doc/changes.rst).
 - Adds lockfile to ensure varnishd is started before running varnishncsa.
 - Adds failure messages to healthcheck script.
 
 ### 2.1.0 - 2018-10-01
 
 - Updates source image to [2.4.0](https://github.com/jdeathe/centos-ssh/releases/tag/2.4.0).
-- Updates Varnish to [6.0.1](https://github.com/varnishcache/varnish-cache/blob/varnish-6.0.1/doc/changes.rst)
+- Updates Varnish to [6.0.1](https://github.com/varnishcache/varnish-cache/blob/varnish-6.0.1/doc/changes.rst).
 - Updates pattern for static assets to include web fonts and SVG images and remove SWF.
 - Removes response header that indicate Varnish version.
 - Adds `VARNISH_AUTOSTART_VARNISHD_WRAPPER` for disabling varnishd autostart.
@@ -68,4 +68,4 @@ CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.2.
 
 ### 2.0.0 - 2018-06-22
 
-- Initial release
+- Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 Summary of release changes for Version 2.
 
-CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.1.
+CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.2.
 
 ### 2.3.0 - Unreleased
 
 - Updates `gcc` package to gcc-4.8.5-36.el7_6.1.
 - Updates source image to [2.5.1](https://github.com/jdeathe/centos-ssh/releases/tag/2.5.1).
+- Updates Varnish to [6.2.0](https://github.com/varnishcache/varnish-cache/blob/varnish-6.2.0/doc/changes.rst)
 - Updates and restructures Dockerfile.
 - Updates container naming conventions and readability of `Makefile`.
 - Updates startup time to 3 seconds.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ ARG RELEASE_VERSION="2.2.1"
 # ------------------------------------------------------------------------------
 RUN { printf -- \
 		'[%s]\nname=%s\nbaseurl=%s\nrepo_gpgcheck=%s\ngpgcheck=%s\nenabled=%s\ngpgkey=%s\nsslverify=%s\nsslcacert=%s\nmetadata_expire=%s\n' \
-		'varnishcache_varnish61' \
-		'varnishcache_varnish61' \
-		'https://packagecloud.io/varnishcache/varnish61/el/7/$basearch' \
+		'varnishcache_varnish62' \
+		'varnishcache_varnish62' \
+		'https://packagecloud.io/varnishcache/varnish62/el/7/$basearch' \
 		'1' \
 		'0' \
 		'1' \
-		'https://packagecloud.io/varnishcache/varnish61/gpgkey' \
+		'https://packagecloud.io/varnishcache/varnish62/gpgkey' \
 		'1' \
 		'/etc/pki/tls/certs/ca-bundle.crt' \
 		'300'; \
@@ -22,7 +22,7 @@ RUN { printf -- \
 		--setopt=tsflags=nodocs \
 		--disableplugin=fastestmirror \
 		gcc-4.8.5-36.el7_6.1 \
-		varnish-6.1.1-1.el7 \
+		varnish-6.2.0-1.el7 \
 	&& yum versionlock add \
 		varnish \
 		gcc \
@@ -107,7 +107,7 @@ jdeathe/centos-ssh-varnish:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-varnish" \
-	org.deathe.description="CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.1."
+	org.deathe.description="CentOS-7 7.5.1804 x86_64 - Varnish Cache 6.2."
 
 HEALTHCHECK \
 	--interval=1s \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ centos-ssh-varnish
 
 Docker Image including:
 - CentOS-6 6.10 x86_64 and Varnish Cache 4.1.
-- CentOS-7 7.5.1804 x86_64 and Varnish Cache 6.1.
+- CentOS-7 7.5.1804 x86_64 and Varnish Cache 6.2.
 
 ## Overview & links
 

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -923,7 +923,7 @@ function test_custom_configuration ()
 			sleep 2
 
 			docker logs \
-				--tail 1 \
+				--tail 3 \
 				varnish.1 \
 			| grep -qE \
 				"^.+ .+ .+ \[.+\] \"GET (http:\/\/${backend_hostname})?/ HTTP/1\.1\" 200 .+ \".+\" \".*\"\$" \
@@ -983,7 +983,7 @@ function test_custom_configuration ()
 			sleep 2
 
 			docker logs \
-				--tail 1 \
+				--tail 3 \
 				varnish.1 \
 			| grep -qE \
 				"^.+ .+ .+ \[.+\] \"GET (http:\/\/${backend_hostname})?/ HTTP/1\.1\" 200 .+ \".+\" \".*\" (hit|miss)+\$" \


### PR DESCRIPTION
CLOSES #172

- Updates Varnish to [6.2.0](https://github.com/varnishcache/varnish-cache/blob/varnish-6.2.0/doc/changes.rst).