### PR TITLE
CLOSES #182: Adds increase in startup time and healthcheck retries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ CentOS-6 6.10 x86_64 - Varnish Cache 4.1.
 - Updates Varnish to version [4.1.11](https://github.com/varnishcache/varnish-cache/blob/varnish-4.1.11/doc/changes.rst).
 - Updates and restructures Dockerfile.
 - Updates container naming conventions and readability of `Makefile`.
-- Updates startup time to 3 seconds.
-- Updates healthcheck retries to 4.
+- Updates startup time to 4 seconds.
+- Updates healthcheck retries to 5.
 - Updates default VCL excluding several parts already defined in `builtin.vcl`.
 - Fixes issue with unexpected published port in run templates when `DOCKER_PORT_MAP_TCP_80` or `DOCKER_PORT_MAP_TCP_8443` is set to an empty string or 0.
 - Fixes binary paths in systemd unit files for compatibility with both EL and Ubuntu hosts.

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ jdeathe/centos-ssh-varnish:${RELEASE_VERSION} \
 HEALTHCHECK \
 	--interval=1s \
 	--timeout=1s \
-	--retries=4 \
+	--retries=5 \
 	CMD ["/usr/bin/healthcheck"]
 
 CMD ["/usr/bin/supervisord", "--configuration=/etc/supervisord.conf"]

--- a/environment.mk
+++ b/environment.mk
@@ -28,7 +28,7 @@ NO_CACHE ?= false
 DIST_PATH ?= ./dist
 
 # Number of seconds expected to complete container startup including bootstrap.
-STARTUP_TIME ?= 3
+STARTUP_TIME ?= 4
 
 # Docker --sysctl settings
 SYSCTL_NET_CORE_SOMAXCONN ?= 1024

--- a/src/opt/scmi/environment.sh
+++ b/src/opt/scmi/environment.sh
@@ -27,7 +27,7 @@ NO_CACHE="${NO_CACHE:-false}"
 DIST_PATH="${DIST_PATH:-./dist}"
 
 # Number of seconds expected to complete container startup including bootstrap.
-STARTUP_TIME="${STARTUP_TIME:-3}"
+STARTUP_TIME="${STARTUP_TIME:-4}"
 
 # Docker --sysctl settings
 SYSCTL_NET_CORE_SOMAXCONN="${SYSCTL_NET_CORE_SOMAXCONN:-1024}"

--- a/src/opt/scmi/service-unit.sh
+++ b/src/opt/scmi/service-unit.sh
@@ -35,4 +35,4 @@ readonly SERVICE_UNIT_REGISTER_ENVIRONMENT_KEYS="
 # ------------------------------------------------------------------------------
 # Variables
 # ------------------------------------------------------------------------------
-SERVICE_UNIT_INSTALL_TIMEOUT="${SERVICE_UNIT_INSTALL_TIMEOUT:-6}"
+SERVICE_UNIT_INSTALL_TIMEOUT="${SERVICE_UNIT_INSTALL_TIMEOUT:-7}"

--- a/test/shpec/operation_shpec.sh
+++ b/test/shpec/operation_shpec.sh
@@ -1,4 +1,4 @@
-readonly STARTUP_TIME=3
+readonly STARTUP_TIME=4
 readonly TEST_DIRECTORY="test"
 
 # These should ideally be a static value but hosts might be using this port so 
@@ -1008,7 +1008,7 @@ function test_healthcheck ()
 	local -r backend_network="bridge_t1"
 	local -r event_lag_seconds=2
 	local -r interval_seconds=1
-	local -r retries=4
+	local -r retries=5
 	local container_id
 	local events_since_timestamp
 	local health_status


### PR DESCRIPTION
CLOSES #182: Patches back #181.

- Updates startup time to 4 seconds.
- Updates healthcheck retries to 5.