### PR TITLE
Release changes for 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Summary of release changes.
 
-### 2.5.0 - Unreleased
+### 2.5.0 - 2019-10-10
 
 - Updates Varnish to [6.3.0](https://github.com/varnishcache/varnish-cache/blob/varnish-6.3.0/doc/changes.rst).
 - Updates image tags in docker-compose example configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Summary of release changes.
 
+### 2.5.0 - Unreleased
+
+- Updates image tags in docker-compose example configuration.
+
 ### 2.4.1 - 2019-10-08
 
 - Deprecate Makefile target `logs-delayed`; replaced with `logsdef`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Summary of release changes.
 
 ### 2.5.0 - Unreleased
 
+- Updates Varnish to [6.3.0](https://github.com/varnishcache/varnish-cache/blob/varnish-6.3.0/doc/changes.rst).
 - Updates image tags in docker-compose example configuration.
 
 ### 2.4.1 - 2019-10-08

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@ ARG RELEASE_VERSION="2.4.1"
 # ------------------------------------------------------------------------------
 RUN { printf -- \
 		'[%s]\nname=%s\nbaseurl=%s\nrepo_gpgcheck=%s\ngpgcheck=%s\nenabled=%s\ngpgkey=%s\nsslverify=%s\nsslcacert=%s\nmetadata_expire=%s\n' \
-		'varnishcache_varnish62' \
-		'varnishcache_varnish62' \
-		'https://packagecloud.io/varnishcache/varnish62/el/7/$basearch' \
+		'varnishcache_varnish63' \
+		'varnishcache_varnish63' \
+		'https://packagecloud.io/varnishcache/varnish63/el/7/$basearch' \
 		'1' \
 		'0' \
 		'1' \
-		'https://packagecloud.io/varnishcache/varnish62/gpgkey' \
+		'https://packagecloud.io/varnishcache/varnish63/gpgkey' \
 		'1' \
 		'/etc/pki/tls/certs/ca-bundle.crt' \
 		'300'; \
@@ -22,7 +22,7 @@ RUN { printf -- \
 		--setopt=tsflags=nodocs \
 		--disableplugin=fastestmirror \
 		gcc-4.8.5-39.el7 \
-		varnish-6.2.1-1.el7 \
+		varnish-6.3.0-1.el7 \
 	&& yum versionlock add \
 		varnish \
 		gcc \
@@ -106,7 +106,7 @@ jdeathe/centos-ssh-varnish:${RELEASE_VERSION} \
 	org.deathe.license="MIT" \
 	org.deathe.vendor="jdeathe" \
 	org.deathe.url="https://github.com/jdeathe/centos-ssh-varnish" \
-	org.deathe.description="Varnish Cache 6.2 - CentOS-7 7.6.1810 x86_64."
+	org.deathe.description="Varnish Cache 6.3 - CentOS-7 7.6.1810 x86_64."
 
 HEALTHCHECK \
 	--interval=1s \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jdeathe/centos-ssh:2.6.1
 
-ARG RELEASE_VERSION="2.4.1"
+ARG RELEASE_VERSION="2.5.0"
 
 # ------------------------------------------------------------------------------
 # Base install of required packages

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Tags and respective `Dockerfile` links
 
-- [`2.4.1`](https://github.com/jdeathe/centos-ssh-varnish/releases/tag/2.4.1), `centos-7` [(centos-7/Dockerfile)](https://github.com/jdeathe/centos-ssh-varnish/blob/centos-7/Dockerfile)
+- [`2.5.0`](https://github.com/jdeathe/centos-ssh-varnish/releases/tag/2.5.0), `centos-7` [(centos-7/Dockerfile)](https://github.com/jdeathe/centos-ssh-varnish/blob/centos-7/Dockerfile)
 - [`1.7.1`](https://github.com/jdeathe/centos-ssh-varnish/releases/tag/1.7.1), `centos-6` [(centos-6/Dockerfile)](https://github.com/jdeathe/centos-ssh-varnish/blob/centos-6/Dockerfile)
 
 ## Overview
@@ -26,7 +26,7 @@ $ docker run -d -t \
   -p 80:80 \
   --sysctl "net.core.somaxconn=1024" \
   --add-host httpd_1:172.17.8.101 \
-  jdeathe/centos-ssh-varnish:2.4.1
+  jdeathe/centos-ssh-varnish:2.5.0
 ```
 
 Verify the named container's process status and health.
@@ -73,7 +73,7 @@ $ docker stop varnish.1 && \
   --env "VARNISH_MAX_THREADS=2000" \
   --env "VARNISH_MIN_THREADS=100" \
   --add-host httpd_1:172.17.8.101 \
-  jdeathe/centos-ssh-varnish:2.4.1
+  jdeathe/centos-ssh-varnish:2.5.0
 ```
 
 #### Environment variables

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This build uses the base image [jdeathe/centos-ssh](https://github.com/jdeathe/c
 
 ### Image variants
 
-- [Varnish Cache 6.2 - CentOS-7](https://github.com/jdeathe/centos-ssh-varnish/blob/centos-7)
+- [Varnish Cache 6.3 - CentOS-7](https://github.com/jdeathe/centos-ssh-varnish/blob/centos-7)
 - [Varnish Cache 4.1 - CentOS-6](https://github.com/jdeathe/centos-ssh-varnish/blob/centos-6)
 
 ## Quick start
@@ -78,7 +78,7 @@ $ docker stop varnish.1 && \
 
 #### Environment variables
 
-There are several environmental variables defined at runtime which allows the operator to customise the running container. This may become necessary under special circumstances and the following show those that are most likely to be considered for review, the rest should be left unaltered and for clarification refer to the [varnishd documentation](https://www.varnish-cache.org/docs/6.0/index.html).
+There are several environmental variables defined at runtime which allows the operator to customise the running container. This may become necessary under special circumstances and the following show those that are most likely to be considered for review, the rest should be left unaltered and for clarification refer to the [varnishd documentation](https://www.varnish-cache.org/docs/6.3/index.html).
 
 ##### ENABLE_VARNISHD_WRAPPER
 
@@ -98,7 +98,7 @@ Use `VARNISH_OPTIONS` to set other `varnishd` options.
 
 ##### VARNISH_STORAGE
 
-Use `VARNISH_STORAGE` to specify the storage backend. See the [varnishd documentation](https://varnish-cache.org/docs/6.0/reference/varnishd.html#storage-backend) for the types and parameters available. The default is a file type backend but it is recommended to use malloc if there is enough RAM available.
+Use `VARNISH_STORAGE` to specify the storage backend. See the [varnishd documentation](https://varnish-cache.org/docs/6.3/reference/varnishd.html#storage-backend) for the types and parameters available. The default is a file type backend but it is recommended to use malloc if there is enough RAM available.
 
 ##### VARNISH_TTL
 
@@ -106,7 +106,7 @@ The `VARNISH_TTL` can be used to set a hard minimum time to live for cached docu
 
 ##### VARNISH_VARNISHNCSA_FORMAT
 
-When `ENABLE_VARNISHNCSA_WRAPPER` is set to `true` then `VARNISH_VARNISHNCSA_FORMAT` can be used to set the output log [format string](https://varnish-cache.org/docs/6.0/reference/varnishncsa.html#format).
+When `ENABLE_VARNISHNCSA_WRAPPER` is set to `true` then `VARNISH_VARNISHNCSA_FORMAT` can be used to set the output log [format string](https://varnish-cache.org/docs/6.3/reference/varnishncsa.html#format).
 
 ##### VARNISH_VARNISHNCSA_OPTIONS
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       PHP_OPTIONS_SESSION_SAVE_HANDLER: "redis"
       PHP_OPTIONS_SESSION_SAVE_PATH: "redis:6379"
       SYSTEM_TIMEZONE: "${SYSTEM_TIMEZONE}"
-    image: "jdeathe/centos-ssh-apache-php:3.3.2"
+    image: "jdeathe/centos-ssh-apache-php:3.3.3"
     networks:
       tier2:
         aliases:
@@ -96,7 +96,7 @@ services:
       REDIS_MAXMEMORY: "32mb"
       REDIS_TCP_BACKLOG: "1024"
       SYSTEM_TIMEZONE: "${SYSTEM_TIMEZONE}"
-    image: "jdeathe/centos-ssh-redis:3.1.0"
+    image: "jdeathe/centos-ssh-redis:4.1.1"
     networks:
       - "tier2"
     ports:


### PR DESCRIPTION
- Updates Varnish to [6.3.0](https://github.com/varnishcache/varnish-cache/blob/varnish-6.3.0/doc/changes.rst).
- Updates image tags in docker-compose example configuration.